### PR TITLE
Move Coverage references inside the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ require 'reverse_coverage'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    ReverseCoverage::Main.instance.start Coverage.peek_result
+    ReverseCoverage::Main.start
   end
 
   config.around do |e|
     e.run
-    ReverseCoverage::Main.instance.add(Coverage.peek_result, e)
+    ReverseCoverage::Main.add(e)
   end
 
   config.after(:suite) do
-    ReverseCoverage::Main.instance.save_results('tmp/reverse_coverage.yml')
+    ReverseCoverage::Main.save_results('tmp/reverse_coverage.yml')
   end
 end
 ```

--- a/lib/reverse_coverage/main.rb
+++ b/lib/reverse_coverage/main.rb
@@ -12,7 +12,9 @@ module ReverseCoverage
       @coverage_matrix = {}
     end
 
-    def add(coverage_result, example)
+    def add(example)
+      coverage_result = Coverage.peek_result
+
       example_data = example.metadata.extract!(*example_attributes)
 
       current_state = select_project_files(coverage_result)
@@ -32,8 +34,8 @@ module ReverseCoverage
       @last_state = current_state
     end
 
-    def start(coverage_result)
-      @last_state = select_project_files(coverage_result)
+    def start
+      @last_state = select_project_files(Coverage.peek_result)
     end
 
     def save_results(path = 'tmp/reverse_coverage.yml')


### PR DESCRIPTION
We are initializing Coverage (.start) in the gem, so IMO we should keep the calls to Coverage methods inside the gem