### PR TITLE
Make gem compatible with Ruby >= 2.7 projects

### DIFF
--- a/lib/reverse_coverage/main.rb
+++ b/lib/reverse_coverage/main.rb
@@ -29,10 +29,8 @@ module ReverseCoverage
         lines.each_with_index do |changed, line_index|
           next if changed.nil? || changed.zero?
 
-          file_info = { file_path: file_path, line_index: line_index }
-
-          save_changes(changes, example_data, file_info)
-          save_changes(coverage_matrix, example_data, file_info)
+          save_changes(changes, example_data, file_path: file_path, line_index: line_index)
+          save_changes(coverage_matrix, example_data, file_path: file_path, line_index: line_index)
         end
       end
 


### PR DESCRIPTION
Fix:

```
ArgumentError:
       wrong number of arguments (given 3, expected 2; required keywords: file_path, line_index)
     # reverse_coverage-0.1.1/lib/reverse_coverage/main.rb:80:in `save_changes'
     # reverse_coverage-0.1.1/lib/reverse_coverage/main.rb:35:in `block (2 levels) in add'
```